### PR TITLE
Implement FastTotp utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,27 @@ This is a Simple Spring boot app which incorporates 2 factor authentication.
 <p>
 This app uses TOTP Algorithm to perform the 2nd Factor Authentication. Any TOTP Mobile App can be used to perform the authentication like Google Authenticator, Microsoft Authenticator,etc.
 </p>
+<p>
+The implementation includes a lightweight `FastTotp` utility for generating and verifying codes with minimal overhead.
+</p>
 <h3> Below is the simple design of the components used: </h3>
 <p align="center">
   <img src="docs/MFA_App_Design_1.svg" />
 </p>
 
+
+## Running locally
+
+Ensure Java 17 is installed. Build and run the application using Maven:
+
+```bash
+mvn spring-boot:run
+```
+
+## Running tests
+
+Execute unit tests with:
+
+```bash
+mvn test
+```

--- a/pom.xml
+++ b/pom.xml
@@ -52,12 +52,6 @@
         </dependency>
 
 
-        <!--TOTP Library-->
-        <dependency>
-            <groupId>org.jboss.aerogear</groupId>
-            <artifactId>aerogear-otp-java</artifactId>
-            <version>1.0.0</version>
-        </dependency>
         <!-- QR Code Library -->
         <dependency>
             <groupId>com.google.zxing</groupId>

--- a/src/main/java/com/duke/mfa/poc/component/CustomAuthProvider.java
+++ b/src/main/java/com/duke/mfa/poc/component/CustomAuthProvider.java
@@ -3,7 +3,6 @@ package com.duke.mfa.poc.component;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.jboss.aerogear.security.otp.Totp;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -19,6 +18,7 @@ import com.duke.mfa.poc.dto.TotpAuthRequestDto;
 import com.duke.mfa.poc.entity.User;
 import com.duke.mfa.poc.repo.UserRepository;
 import com.duke.mfa.poc.utils.PasswordUtils;
+import com.duke.mfa.poc.utils.FastTotp;
 
 /**
  * @author Kazi
@@ -82,8 +82,7 @@ public class CustomAuthProvider {
         boolean validTotp = PasswordUtils.validateTotp(totpCode);
         if (!validTotp)
             throw new BadCredentialsException("Invalid OTP.");
-        Totp totp = new Totp(PasswordUtils.getBase32TotpSecret(principal.getTotpSecret()));
-        boolean totpVerified = totp.verify(totpCode);
+        boolean totpVerified = FastTotp.verifyCode(principal.getTotpSecret(), totpCode, 1, 6);
         if (!totpVerified)
             throw new BadCredentialsException("Invalid OTP.");
         principal.setMfAuthenticated(true);

--- a/src/main/java/com/duke/mfa/poc/utils/FastTotp.java
+++ b/src/main/java/com/duke/mfa/poc/utils/FastTotp.java
@@ -1,0 +1,58 @@
+package com.duke.mfa.poc.utils;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import org.bouncycastle.util.encoders.Base32;
+
+/**
+ * A lightweight Time based OTP generator and verifier.
+ */
+public final class FastTotp {
+    private static final int DEFAULT_TIME_STEP_SECONDS = 30;
+    private static final String HMAC_ALGORITHM = "HmacSHA1";
+
+    private FastTotp() {
+    }
+
+    static byte[] decodeBase32(String secret) {
+        return Base32.decode(secret);
+    }
+
+    static int generateCode(byte[] key, long timestep, int digits) {
+        try {
+            ByteBuffer buffer = ByteBuffer.allocate(8).order(ByteOrder.BIG_ENDIAN);
+            buffer.putLong(timestep);
+            Mac mac = Mac.getInstance(HMAC_ALGORITHM);
+            mac.init(new SecretKeySpec(key, HMAC_ALGORITHM));
+            byte[] hash = mac.doFinal(buffer.array());
+            int offset = hash[hash.length - 1] & 0x0F;
+            int binary = ((hash[offset] & 0x7F) << 24) | ((hash[offset + 1] & 0xFF) << 16)
+                    | ((hash[offset + 2] & 0xFF) << 8) | (hash[offset + 3] & 0xFF);
+            int otp = binary % (int) Math.pow(10, digits);
+            return otp;
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to generate TOTP", e);
+        }
+    }
+
+    public static String generateCurrentCode(char[] secret, int digits) {
+        long timestep = System.currentTimeMillis() / 1000L / DEFAULT_TIME_STEP_SECONDS;
+        byte[] key = decodeBase32(PasswordUtils.getBase32TotpSecret(secret));
+        int code = generateCode(key, timestep, digits);
+        return String.format("%0" + digits + "d", code);
+    }
+
+    public static boolean verifyCode(char[] secret, String code, int window, int digits) {
+        long timestep = System.currentTimeMillis() / 1000L / DEFAULT_TIME_STEP_SECONDS;
+        byte[] key = decodeBase32(PasswordUtils.getBase32TotpSecret(secret));
+        for (int i = -window; i <= window; i++) {
+            int candidate = generateCode(key, timestep + i, digits);
+            if (code.equals(String.format("%0" + digits + "d", candidate))) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/test/java/com/duke/mfa/poc/utils/FastTotpTest.java
+++ b/src/test/java/com/duke/mfa/poc/utils/FastTotpTest.java
@@ -1,0 +1,24 @@
+package com.duke.mfa.poc.utils;
+
+import junit.framework.TestCase;
+
+/**
+ * Tests for {@link FastTotp}.
+ */
+public class FastTotpTest extends TestCase {
+
+    public void testGenerateCode() {
+        String secret = "JBSWY3DPEHPK3PXP"; // base32 for 'Hello!1234'
+        byte[] key = FastTotp.decodeBase32(secret);
+        assertEquals(282760, FastTotp.generateCode(key, 0, 6));
+        assertEquals(996554, FastTotp.generateCode(key, 1, 6));
+        assertEquals(602287, FastTotp.generateCode(key, 2, 6));
+        assertEquals(143627, FastTotp.generateCode(key, 3, 6));
+    }
+
+    public void testVerifyCode() {
+        char[] secret = "Hello!1234".toCharArray();
+        String code = FastTotp.generateCurrentCode(secret, 6);
+        assertTrue(FastTotp.verifyCode(secret, code, 0, 6));
+    }
+}


### PR DESCRIPTION
## Summary
- implement a lightweight FastTotp OTP generator
- integrate FastTotp in `CustomAuthProvider`
- remove Aerogear dependency
- add unit tests for FastTotp
- document running the app and tests in README

## Testing
- `mvn test` *(fails: `mvn: command not found`)*